### PR TITLE
Add key VAR for magnetic variation / declination

### DIFF
--- a/scripts/openAIP2.py
+++ b/scripts/openAIP2.py
@@ -410,6 +410,9 @@ def readOpenAIPAirports(airportData):
            
         # Get further properties
         properties['TYP'] = 'AD'
+
+        if 'magneticDeclination' in item:
+            properties['VAR'] = item['magneticDeclination']
         
         #
         # Generate feature
@@ -657,6 +660,9 @@ def readOpenAIPNavaids():
 
         properties['MOR'] = morse(item['identifier'])
         properties['TYP'] = 'NAV'
+
+        if 'magneticDeclination' in item:
+            properties['VAR'] = item['magneticDeclination']
 
         #
         # Generate feature


### PR DESCRIPTION
[Magnetic variation](https://en.wikipedia.org/wiki/Magnetic_declination) is useful when navigating by compass. Furthermore, directional beacons (e.g. VOR) are [referenced to magnetic north](https://en.wikipedia.org/wiki/VHF_omnidirectional_range).

OpenAIP already has variation information for airports and navaids. I have copied these over to your geojson format.

Using a script, I verified how many airports and navaids currently have variation information:
```
jq 'reduce (.features[] | select(.properties.TYP == "AD" or .properties.TYP == "NAV")) as $item (
  {"is_number": 0, "not_number": 0};
  if ($item.properties.VAR | type) == "number" then
    .is_number += 1
  else
    .not_number += 1
  end
)' worldAviationMap.geojson
```
Which currently returns 41338 features with VAR information and zero without.